### PR TITLE
Updating Terraform State S3 bucket resources to new format required in AWS Provider v4.0.0

### DIFF
--- a/Terraform-AWS-Services-Creation/1-Create-S3-Bucket-To-Store-TFSTATE-Files.md
+++ b/Terraform-AWS-Services-Creation/1-Create-S3-Bucket-To-Store-TFSTATE-Files.md
@@ -12,6 +12,7 @@ The Terraform `main.tf` will do a few things:
 - Utilize AES256 encryption 
 
 2. Create the bucket by running the following:
+- Adding a random number to the end of the bucket name in the main.tf file (as S3 bucket names must be globally unique)
 - `terraform init` - To initialize the working directory and pull down the provider
 - `terraform plan` - To go through a "check" and confirm the configurations are valid
 - `terraform apply - To create the resource

--- a/Terraform-AWS-Services-Creation/terraform-state-s3-bucket/main.tf
+++ b/Terraform-AWS-Services-Creation/terraform-state-s3-bucket/main.tf
@@ -3,16 +3,21 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "terraform_state" {
-  bucket = "terraform-state-devopsthehardway"
-  versioning {
-    enabled = true
-  }
+  bucket = "terraform-state-devopsthehardwayXXXX" #Replace the XXXX with random digits (as S3 bucket names must be globally unique in AWS)
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_versioning" "terraform_state_versioning" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state_encryption" {
+  bucket = aws_s3_bucket.terraform_state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }


### PR DESCRIPTION
Full details around changes in new provider version here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3-bucket-refactor

Have also added a note about adding random numbers to the end of the S3 bucket name (to ensure it is globally unique).