### PR TITLE
Re-Order COPY commands to enhance build time.

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,11 +3,11 @@ FROM python:latest
 RUN mkdir /build
 WORKDIR /build
 
-COPY app /build
-
 COPY app/requirements.txt /build
 
 RUN pip install -r requirements.txt
+
+COPY app /build
 
 EXPOSE 5000
 


### PR DESCRIPTION
When we copy dependencies and build it first , this will make build time faster if we change the code later. In This new Dockerfile if you change the python code, docker will use the cached layer of dependencies and save you some computing time.

You can also remove `RUN mkdir /build` because the `WORKDIR /build` command make new dir if it isn't found.